### PR TITLE
OS Windows additional items

### DIFF
--- a/ICMP/ICMP.xml
+++ b/ICMP/ICMP.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T03:53:50Z</date>
+  <date>2017-12-09T23:26:30Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -13,11 +13,13 @@
       <name>ICMP</name>
       <description>Base ICMP template checking availability of the host using ICMP protocol.&#13;
 &#13;
-Version : 1.0.1 (2017-10-13)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/ICMP&#13;
+Current version : 1.0&#13;
+Date:                   2017-09-09&#13;
+Changelog:&#13;
+1.0:&#13;
+- initial version.&#13;
 &#13;
-Notes:&#13;
-- This template is used by all OS and SNMP Devices templates</description>
+Notes:</description>
       <groups>
         <group>
           <name>Templates</name>
@@ -36,7 +38,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>icmpping</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>1w</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -159,59 +161,7 @@ Notes:&#13;
       <httptests/>
       <macros/>
       <templates/>
-      <screens>
-        <screen>
-          <name>NET::ICMP</name>
-          <hsize>1</hsize>
-          <vsize>2</vsize>
-          <screen_items>
-            <screen_item>
-              <resourcetype>0</resourcetype>
-              <width>900</width>
-              <height>200</height>
-              <x>0</x>
-              <y>0</y>
-              <colspan>1</colspan>
-              <rowspan>1</rowspan>
-              <elements>0</elements>
-              <valign>1</valign>
-              <halign>1</halign>
-              <style>0</style>
-              <url/>
-              <dynamic>0</dynamic>
-              <sort_triggers>0</sort_triggers>
-              <resource>
-                <name>NET::ICMP</name>
-                <host>ICMP</host>
-              </resource>
-              <max_columns>3</max_columns>
-              <application/>
-            </screen_item>
-            <screen_item>
-              <resourcetype>0</resourcetype>
-              <width>900</width>
-              <height>200</height>
-              <x>0</x>
-              <y>1</y>
-              <colspan>1</colspan>
-              <rowspan>1</rowspan>
-              <elements>0</elements>
-              <valign>1</valign>
-              <halign>1</halign>
-              <style>0</style>
-              <url/>
-              <dynamic>0</dynamic>
-              <sort_triggers>0</sort_triggers>
-              <resource>
-                <name>NET::ICMP::latency</name>
-                <host>ICMP</host>
-              </resource>
-              <max_columns>3</max_columns>
-              <application/>
-            </screen_item>
-          </screen_items>
-        </screen>
-      </screens>
+      <screens/>
     </template>
   </templates>
   <triggers>

--- a/OS Linux/OS Linux.xml
+++ b/OS Linux/OS Linux.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T03:53:54Z</date>
+  <date>2017-12-01T18:45:16Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -11,13 +11,27 @@
     <template>
       <template>OS Linux</template>
       <name>OS Linux</name>
-      <description>Base Linux monitoring template.&#13;
+      <description>Base Linux monitoring template compliant with EL7 and compatible.&#13;
 &#13;
-Version: 1.0.2 (2017-11-30)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/OS%20Linux&#13;
-&#13;
+Current version : 1.0.1&#13;
+Date:                   2017-10-15&#13;
 Notes:&#13;
-- compliant with EL7 and compatible</description>
+&#13;
+Changelog:&#13;
+1.0.1:&#13;
+- added HW applicatiom&#13;
+- added items in HW application:&#13;
+ - SYS::CPU - monitor CPUs description data using system.hw.cpu[]&#13;
+ - SYS::devices - monitor list of the devices using system.hw.devices[]&#13;
+- renamed item:&#13;
+ - SYS::CPU::cores to HW::CPU::cores and moved to HW application&#13;
+- added triggers &#13;
+ - HW::CPU has changed&#13;
+ - HW::devices has changed&#13;
+- remove using @OS Linux::NET regexp network interfaces filter and replace by regexp (?!(lo)) (no global regexp needed now)&#13;
+&#13;
+1.0:&#13;
+- initial version.</description>
       <groups>
         <group>
           <name>Templates</name>
@@ -63,7 +77,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>net.if.in[lo,bytes]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -109,7 +123,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>net.if.out[lo,bytes]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -155,7 +169,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>net.tcp.port[,22]</key>
           <delay>5m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -198,7 +212,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>net.tcp.service[ssh]</key>
           <delay>5m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -241,7 +255,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>proc.num[,,run]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -282,7 +296,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>proc.num[crond]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -323,7 +337,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>proc.num[rsyslogd]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -364,7 +378,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>proc.num[sshd]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -405,7 +419,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>proc.num[]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -446,7 +460,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>system.boottime</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -487,7 +501,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>system.cpu.intr</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -533,7 +547,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>system.cpu.load[,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -574,7 +588,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>system.cpu.num[max]</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -615,7 +629,7 @@ Notes:&#13;
           <snmp_oid/>
           <key>system.cpu.switches</key>
           <delay>5s</delay>
-          <history>2w</history>
+          <history>365d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -663,7 +677,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,idle,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -704,7 +718,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,interrupt,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -745,7 +759,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,iowait,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -786,7 +800,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,nice,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -827,7 +841,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,softirq,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -868,7 +882,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,steal,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -909,7 +923,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,system,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -950,7 +964,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,user,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -990,8 +1004,8 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>system.hostname</key>
-          <delay>6h</delay>
-          <history>2w</history>
+          <delay>5h</delay>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -1032,7 +1046,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.hw.cpu</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>4</value_type>
@@ -1073,7 +1087,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.hw.devices</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>4</value_type>
@@ -1114,7 +1128,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.localtime</key>
           <delay>15m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1155,7 +1169,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)connections aborted due to timeout/\1/ p'"]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1201,7 +1215,53 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)failed connection attempts/\1/ p'"]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units>events/s</units>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description/>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>NET</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing>
+            <step>
+              <type>10</type>
+              <params/>
+            </step>
+          </preprocessing>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>NET::Other TCP timeouts</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)other TCP timeouts/\1/ p'"]</key>
+          <delay>1m</delay>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1245,9 +1305,9 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
-          <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\) segments retransmitted*/\1/ p'"]</key>
+          <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)segments retransmited.*/\1/ p'"]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1292,8 +1352,8 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["cat /etc/redhat-release"]</key>
-          <delay>6h</delay>
-          <history>2w</history>
+          <delay>5h</delay>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -1333,8 +1393,8 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>system.sw.os[full]</key>
-          <delay>6h</delay>
-          <history>2w</history>
+          <delay>5h</delay>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -1375,7 +1435,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.sw.packages</key>
           <delay>6h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>4</value_type>
@@ -1415,8 +1475,8 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>system.uname</key>
-          <delay>6h</delay>
-          <history>2w</history>
+          <delay>5h</delay>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -1457,7 +1517,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.uptime</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1498,7 +1558,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.users.num</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1539,7 +1599,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vfs.file.cksum[/etc/passwd]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1580,7 +1640,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vfs.file.cksum[/usr/bin/ssh]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1621,7 +1681,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vfs.file.cksum[/usr/sbin/sshd]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1662,7 +1722,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[available]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1703,7 +1763,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[buffers]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1744,7 +1804,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[cached]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1785,7 +1845,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[free]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1826,7 +1886,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[total]</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1867,7 +1927,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>vm.memory.size[used]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1909,7 +1969,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>net.if.discovery</key>
-          <delay>10m</delay>
+          <delay>5m</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -1933,13 +1993,13 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
             <conditions>
               <condition>
                 <macro>{#IFNAME}</macro>
-                <value>^(?!(lo))</value>
+                <value>(?!(lo))</value>
                 <operator>8</operator>
                 <formulaid>A</formulaid>
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>1w</lifetime>
           <description>Discovery of network interfaces.</description>
           <item_prototypes>
             <item_prototype>
@@ -1949,7 +2009,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.in[{#IFNAME},bytes]</key>
               <delay>15s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -1996,7 +2056,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.in[{#IFNAME},packets]</key>
               <delay>15s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2043,7 +2103,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.out[{#IFNAME},bytes]</key>
               <delay>15s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2090,7 +2150,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.out[{#IFNAME},packets]</key>
               <delay>15s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2137,7 +2197,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.total[{#IFNAME},dropped]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2184,7 +2244,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               <snmp_oid/>
               <key>net.if.total[{#IFNAME},errors]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2403,6 +2463,18 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
                   </item>
                 </graph_item>
                 <graph_item>
+                  <sortorder>3</sortorder>
+                  <drawtype>0</drawtype>
+                  <color>C800C8</color>
+                  <yaxisside>0</yaxisside>
+                  <calc_fnc>7</calc_fnc>
+                  <type>0</type>
+                  <item>
+                    <host>OS Linux</host>
+                    <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)other TCP timeouts/\1/ p'"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
                   <sortorder>4</sortorder>
                   <drawtype>0</drawtype>
                   <color>999999</color>
@@ -2411,7 +2483,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
                   <type>0</type>
                   <item>
                     <host>OS Linux</host>
-                    <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\) segments retransmitted*/\1/ p'"]</key>
+                    <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)segments retransmited.*/\1/ p'"]</key>
                   </item>
                 </graph_item>
               </graph_items>
@@ -2514,7 +2586,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["awk 'BEGIN {print \"{\\"data\\":[\"; ORS=\"\"} {if (NR!=1) {print \",\n\"}; print \"{\\"{#DISK}\\":\\"\" $3 \"\\"}\"} END {print \"\n]}\"}' /proc/diskstats"]</key>
-          <delay>10m</delay>
+          <delay>1h</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -2544,7 +2616,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>List of Linux SCSI, ATA, XEN and Device Mapper storage devices without partitions.&#13;
 Discovery of storage devices is filtered over global regular expression "OS Linux::BlkDev" regexp.&#13;
 &#13;
@@ -2557,7 +2629,7 @@ Discovery of storage devices is filtered over global regular expression "OS Linu
               <snmp_oid/>
               <key>vfs.dev.read[{#DISK},operations]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2604,7 +2676,7 @@ Discovery of storage devices is filtered over global regular expression "OS Linu
               <snmp_oid/>
               <key>vfs.dev.read[{#DISK},sectors]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2656,7 +2728,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.dev.write[{#DISK},operations]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2703,7 +2775,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.dev.write[{#DISK},sectors]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2849,7 +2921,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
           <snmp_community/>
           <snmp_oid/>
           <key>vfs.fs.discovery</key>
-          <delay>10m</delay>
+          <delay>1h</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -2868,24 +2940,18 @@ Value is calculated by read number of sectors multiplied by 512.</description>
           <privatekey/>
           <port/>
           <filter>
-            <evaltype>1</evaltype>
+            <evaltype>0</evaltype>
             <formula/>
             <conditions>
               <condition>
                 <macro>{#FSTYPE}</macro>
                 <value>^(btrfs|ext2|ext3|ext4|jfs|reiser|xfs|ffs|ufs|jfs|jfs2|vxfs|hfs|refs|ntfs|fat32|zfs)$</value>
                 <operator>8</operator>
-                <formulaid>B</formulaid>
-              </condition>
-              <condition>
-                <macro>{#FSNAME}</macro>
-                <value>(?!(^/run/media))</value>
-                <operator>8</operator>
                 <formulaid>A</formulaid>
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>0</lifetime>
           <description>Discovery of file systems.</description>
           <item_prototypes>
             <item_prototype>
@@ -2895,7 +2961,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.inode[{#FSNAME},pfree]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2937,7 +3003,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.inode[{#FSNAME},total]</key>
               <delay>1d</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2979,7 +3045,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.inode[{#FSNAME},used]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3021,7 +3087,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},pfree]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -3042,7 +3108,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <publickey/>
               <privatekey/>
               <port/>
-              <description>Percent used volume space.</description>
+              <description/>
               <inventory_link>0</inventory_link>
               <applications>
                 <application>
@@ -3063,7 +3129,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},total]</key>
               <delay>1d</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3084,7 +3150,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <publickey/>
               <privatekey/>
               <port/>
-              <description>Volume total space.</description>
+              <description/>
               <inventory_link>0</inventory_link>
               <applications>
                 <application>
@@ -3105,7 +3171,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},used]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3126,7 +3192,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
               <publickey/>
               <privatekey/>
               <port/>
-              <description>Volume used space.</description>
+              <description/>
               <inventory_link>0</inventory_link>
               <applications>
                 <application>
@@ -4004,13 +4070,13 @@ Value is calculated by read number of sectors multiplied by 512.</description>
       <expression>{OS Linux:system.hw.devices.str()}&lt;&gt;0</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
-      <name>HW::devices list has been changed</name>
+      <name>HW::devices has changed</name>
       <correlation_mode>0</correlation_mode>
       <correlation_tag/>
       <url/>
       <status>0</status>
       <priority>1</priority>
-      <description>Hardware devices list has been changed.</description>
+      <description>List of devices has been changed.</description>
       <type>1</type>
       <manual_close>0</manual_close>
       <dependencies/>
@@ -4328,7 +4394,7 @@ s3-dump hosts delete</description>
       <expression>{OS Linux:system.uname.diff(0)}&gt;0</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
-      <name>SYS:uname changed</name>
+      <name>SYS::uname changed</name>
       <correlation_mode>0</correlation_mode>
       <correlation_tag/>
       <url/>
@@ -4577,6 +4643,18 @@ s3-dump hosts delete</description>
           <item>
             <host>OS Linux</host>
             <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)connections aborted due to timeout/\1/ p'"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>4</drawtype>
+          <color>00C800</color>
+          <yaxisside>0</yaxisside>
+          <calc_fnc>2</calc_fnc>
+          <type>0</type>
+          <item>
+            <host>OS Linux</host>
+            <key>system.run["/bin/netstat -s|/bin/sed -n 's/\(.*\)other TCP timeouts/\1/ p'"]</key>
           </item>
         </graph_item>
         <graph_item>

--- a/OS Linux/OS Linux.xml
+++ b/OS Linux/OS Linux.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-<<<<<<< HEAD
-  <date>2017-12-01T18:45:16Z</date>
-=======
-  <date>2017-12-05T23:01:44Z</date>
->>>>>>> e22bebf6a03819125e57f8f6ded44d3d5849e4a7
+  <date>2017-12-09T23:26:31Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -15,14 +11,7 @@
     <template>
       <template>OS Linux</template>
       <name>OS Linux</name>
-<<<<<<< HEAD
       <description>Base Linux monitoring template compliant with EL7 and compatible.&#13;
-=======
-      <description>Base Linux monitoring template.&#13;
-&#13;
-Version: 1.0.3 (2017-12-05)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/OS%20Linux&#13;
->>>>>>> e22bebf6a03819125e57f8f6ded44d3d5849e4a7
 &#13;
 Current version : 1.0.1&#13;
 Date:                   2017-10-15&#13;
@@ -2958,15 +2947,6 @@ Value is calculated by read number of sectors multiplied by 512.</description>
                 <macro>{#FSTYPE}</macro>
                 <value>^(btrfs|ext2|ext3|ext4|jfs|reiser|xfs|ffs|ufs|jfs|jfs2|vxfs|hfs|refs|ntfs|fat32|zfs)$</value>
                 <operator>8</operator>
-<<<<<<< HEAD
-=======
-                <formulaid>B</formulaid>
-              </condition>
-              <condition>
-                <macro>{#FSNAME}</macro>
-                <value>^(?!(^/run/media))</value>
-                <operator>8</operator>
->>>>>>> e22bebf6a03819125e57f8f6ded44d3d5849e4a7
                 <formulaid>A</formulaid>
               </condition>
             </conditions>

--- a/OS Solaris/OS Solaris.xml
+++ b/OS Solaris/OS Solaris.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T02:28:30Z</date>
+  <date>2017-12-09T23:26:32Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -13,10 +13,57 @@
       <name>OS Solaris</name>
       <description>Base OS Solaris monitoring.&#13;
 &#13;
-Version: 1.0.1 (2017-12-01)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/OS%20Solaris&#13;
+Current version : 1.0&#13;
+Date:                   2017-09-09&#13;
+Changelog:&#13;
+1.0:&#13;
+- initial version.&#13;
 &#13;
-Notes:</description>
+Notes:&#13;
+https://github.com/mharsch/arcstat/blob/master/arcstat.pl&#13;
+http://dtrace.org/blogs/brendan/2012/01/09/activity-of-the-zfs-arc/&#13;
+&#13;
+Possible to add kstat ARC metrics:&#13;
+&#13;
+zfs:0:arcstats:buf_size&#13;
+zfs:0:arcstats:class&#13;
+zfs:0:arcstats:crtime&#13;
+zfs:0:arcstats:data_size&#13;
+zfs:0:arcstats:deleted&#13;
+zfs:0:arcstats:evict_l2_cached&#13;
+zfs:0:arcstats:evict_l2_eligible&#13;
+zfs:0:arcstats:evict_l2_ineligible&#13;
+zfs:0:arcstats:evict_mfu&#13;
+zfs:0:arcstats:evict_mru&#13;
+zfs:0:arcstats:hash_chain_max&#13;
+zfs:0:arcstats:hash_chains&#13;
+zfs:0:arcstats:hash_collisions&#13;
+zfs:0:arcstats:hash_elements&#13;
+zfs:0:arcstats:hash_elements_max&#13;
+zfs:0:arcstats:l2_abort_lowmem&#13;
+zfs:0:arcstats:l2_cksum_bad&#13;
+zfs:0:arcstats:l2_evict_lock_retry&#13;
+zfs:0:arcstats:l2_evict_reading&#13;
+zfs:0:arcstats:l2_feeds&#13;
+zfs:0:arcstats:l2_hdr_size&#13;
+zfs:0:arcstats:l2_io_error&#13;
+zfs:0:arcstats:l2_read_bytes&#13;
+zfs:0:arcstats:l2_rw_clash&#13;
+zfs:0:arcstats:l2_size&#13;
+zfs:0:arcstats:l2_write_bytes&#13;
+zfs:0:arcstats:l2_writes_done&#13;
+zfs:0:arcstats:l2_writes_error&#13;
+zfs:0:arcstats:l2_writes_hdr_miss&#13;
+zfs:0:arcstats:l2_writes_sent&#13;
+zfs:0:arcstats:meta_limit&#13;
+zfs:0:arcstats:meta_max&#13;
+zfs:0:arcstats:meta_used&#13;
+zfs:0:arcstats:mutex_miss&#13;
+zfs:0:arcstats:other_size&#13;
+zfs:0:arcstats:p&#13;
+zfs:0:arcstats:snaptime&#13;
+&#13;
+https://github.com/bcantrill/node-kstat</description>
       <groups>
         <group>
           <name>Templates</name>
@@ -62,7 +109,7 @@ Notes:</description>
           <snmp_oid/>
           <key>icmpping[]</key>
           <delay>2m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -105,7 +152,7 @@ Notes:</description>
           <snmp_oid/>
           <key>net.tcp.port[,22]</key>
           <delay>5m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -148,7 +195,7 @@ Notes:</description>
           <snmp_oid/>
           <key>net.tcp.service[ssh]</key>
           <delay>5m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -191,7 +238,7 @@ Notes:</description>
           <snmp_oid/>
           <key>proc.num[,,run]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -232,7 +279,7 @@ Notes:</description>
           <snmp_oid/>
           <key>proc.num[crond]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -273,7 +320,7 @@ Notes:</description>
           <snmp_oid/>
           <key>proc.num[ntpd]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -314,7 +361,7 @@ Notes:</description>
           <snmp_oid/>
           <key>proc.num[sshd]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -355,7 +402,7 @@ Notes:</description>
           <snmp_oid/>
           <key>proc.num[]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -396,7 +443,7 @@ Notes:</description>
           <snmp_oid/>
           <key>system.boottime</key>
           <delay>10m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -437,7 +484,7 @@ Notes:</description>
           <snmp_oid/>
           <key>system.cpu.intr</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -483,7 +530,7 @@ Notes:</description>
           <snmp_oid/>
           <key>system.cpu.load[,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -524,7 +571,7 @@ Notes:</description>
           <snmp_oid/>
           <key>system.cpu.num[max]</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -565,7 +612,7 @@ Notes:</description>
           <snmp_oid/>
           <key>system.cpu.switches</key>
           <delay>5s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -613,7 +660,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,idle,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -654,7 +701,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,iowait,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -695,7 +742,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,system,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -736,7 +783,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.cpu.util[,user,avg1]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -777,7 +824,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.hostname</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -818,7 +865,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.localtime</key>
           <delay>15m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -859,7 +906,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <snmp_oid/>
           <key>system.run["kstat -p zfs:*:arcstats:c_max|cut -f2'"]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -905,7 +952,7 @@ set zfs:zfs_arc_max=34359738368</description>
           <snmp_oid/>
           <key>system.run["kstat -p zfs:*:arcstats:c_min|cut -f2'"]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -946,7 +993,7 @@ set zfs:zfs_arc_max=34359738368</description>
           <snmp_oid/>
           <key>system.run["kstat -p zfs:*:arcstats:c|cut -f2'"]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -987,7 +1034,7 @@ set zfs:zfs_arc_max=34359738368</description>
           <snmp_oid/>
           <key>system.run["kstat -p zfs:*:arcstats:demand_data_hits | cut -f2'"]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1037,7 +1084,7 @@ streaming ratio = prefetch_* / (hits + misses)</description>
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*::prefetch_data_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1085,7 +1132,7 @@ Prefetch is the ZFS read-ahead feature, to predict and pre-cache blocks for stre
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*::prefetch_metadata_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1133,7 +1180,7 @@ Prefetch is the ZFS read-ahead feature, to predict and pre-cache blocks for stre
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:demand_data_misses|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1183,7 +1230,7 @@ streaming ratio = prefetch_* / (hits + misses)</description>
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:demand_metadata_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1233,7 +1280,7 @@ streaming ratio = prefetch_* / (hits + misses)</description>
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:demand_metadata_misses|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1283,7 +1330,7 @@ streaming ratio = prefetch_* / (hits + misses)</description>
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:hits|cut -f2]</key>
           <delay>5s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1331,7 +1378,7 @@ hits = demand_data_hits + demand_metadata_hits + prefetch_data_hits + prefetch_m
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:memory_throttle_count|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1381,7 +1428,7 @@ A constant increasing of the memory_throttle_count statistic can indicate excess
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:mfu_ghost_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1429,7 +1476,7 @@ hits against pages held in ghost mfu list from pages evicted from ARC mfu list</
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:mfu_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1475,7 +1522,7 @@ hits against pages held in ghost mfu list from pages evicted from ARC mfu list</
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:misses|cut -f2]</key>
           <delay>5s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1523,7 +1570,7 @@ misses = demand_data_misses + demand_metadata_misses + prefetch_data_misses + pr
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:mru_ghost_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1571,7 +1618,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:mru_hits|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1617,7 +1664,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.run[kstat -p zfs:*:arcstats:size|cut -f2]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1658,7 +1705,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.swap.size[,free]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1699,7 +1746,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.swap.size[,total]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1740,7 +1787,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.uname</key>
           <delay>5h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -1781,7 +1828,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.uptime</key>
           <delay>10m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1822,7 +1869,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>system.users.num</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1866,7 +1913,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>vfs.file.cksum[/etc/passwd]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1907,7 +1954,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>vm.memory.size[available]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1948,7 +1995,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>vm.memory.size[free]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1989,7 +2036,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>vm.memory.size[total]</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2030,7 +2077,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>vm.memory.size[used]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2071,7 +2118,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_oid/>
           <key>zabbix[items_unsupported,host]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2113,7 +2160,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_community/>
           <snmp_oid/>
           <key>net.if.discovery</key>
-          <delay>10m</delay>
+          <delay>1d</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -2149,7 +2196,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>Discovery of network interfaces.</description>
           <item_prototypes>
             <item_prototype>
@@ -2159,7 +2206,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>net.if.in[{#IFNAME}]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>1w</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2210,7 +2257,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>net.if.out[{#IFNAME}]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>1w</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -2355,7 +2402,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["iostat -x|awk 'BEGIN {print \"{\\"data\\":[\"; ORS=\"\"} {if (NR&gt;3) {print \",\n\"}; if (NR&gt;2) print \"{\\"{#DISK}\\":\\"\" $1 \"\\"}\"} END {print \"]}\"}'"]</key>
-          <delay>10m</delay>
+          <delay>1d</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -2385,7 +2432,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>List of Solaris storage devices (typically displayed by iostat -x).</description>
           <item_prototypes>
             <item_prototype>
@@ -2395,7 +2442,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>vfs.dev.read.size[{#DISK}]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2437,7 +2484,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>vfs.dev.read[{#DISK},bytes]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2484,7 +2531,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>vfs.dev.read[{#DISK},operations]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2531,7 +2578,7 @@ Hits against pages held in ghost mru list from pages evicted from ARC mru list</
               <snmp_oid/>
               <key>vfs.dev.write.size[{#DISK}]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2574,7 +2621,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>vfs.dev.write[{#DISK},bytes]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2621,7 +2668,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>vfs.dev.write[{#DISK},operations]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2806,7 +2853,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["kstat -p zfs::arcstats:l2_hdr_size|awk '/(.*\t0$)/{print \"{\\"data\\":[ ]}\"} !/(.*\t0$)/{print \"{\\"data\\":[{\\"{#L2ARC}\\":\\"*\\"}]}\"}''"]</key>
-          <delay>10m</delay>
+          <delay>1d</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -2829,8 +2876,10 @@ last("vfs.dev.write[{#DISK},operations]")</params>
             <formula/>
             <conditions/>
           </filter>
-          <lifetime>1d</lifetime>
-          <description>Using unix:0:l2arc_buf_t:alloc kstat metrics detect does zfs pools are using L2ARC or not.</description>
+          <lifetime>30d</lifetime>
+          <description>Using unix:0:l2arc_buf_t:alloc kstat metrics detect does zfs pools are using L2ARC or not.&#13;
+&#13;
+system.run["kstat -p zfs::arcstats:l2_hdr_size|awk '/(.*\t0$)/{print \"{\\"data\\":[ ]}\"} !/(.*\t0$)/{print \"{\\"data\\":[{\\"{#L2ARC}\\":\\"*\\"}]}\"}''"]</description>
           <item_prototypes>
             <item_prototype>
               <name>zfs:{#L2ARC}:arcstats:l2_feeds</name>
@@ -2839,7 +2888,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run["kstat -p zfs:{#L2ARC}:arcstats:l2_feeds|cut -f2'"]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2886,7 +2935,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run["kstat -p zfs:{#L2ARC}:arcstats:l2_hits|cut -f2'"]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2933,7 +2982,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run["kstat -p zfs:{#L2ARC}:arcstats:l2_misses|cut -f2'"]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -2980,7 +3029,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run["kstat -p zfs:{#L2ARC}:arcstats:l2_size|cut -f2'"]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3022,7 +3071,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run["kstat -p zfs:{#L2ARC}:arcstats:l2_write_bytes|cut -f2'"]</key>
               <delay>30s</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -3119,7 +3168,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["zpool list -Ho name|awk 'BEGIN {print \"{\\"data\\":[\"; ORS=\"\"} {if (NR&gt;1) {print \",\n\"}; print \"{\\"{#ZPOOL}\\":\\"\" $1 \"\\"}\"} END {print \"]}\"}'"]</key>
-          <delay>10m</delay>
+          <delay>1d</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -3142,7 +3191,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
             <formula/>
             <conditions/>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>List of zpools.</description>
           <item_prototypes>
             <item_prototype>
@@ -3152,7 +3201,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run[zpool list -Ho health {#ZPOOL}]</key>
               <delay>10m</delay>
-              <history>2w</history>
+              <history>365d</history>
               <trends>0</trends>
               <status>0</status>
               <value_type>1</value_type>
@@ -3194,7 +3243,7 @@ last("vfs.dev.write[{#DISK},operations]")</params>
               <snmp_oid/>
               <key>system.run[zpool list -Ho version {#ZPOOL}]</key>
               <delay>1d</delay>
-              <history>2w</history>
+              <history>365d</history>
               <trends>0</trends>
               <status>0</status>
               <value_type>1</value_type>
@@ -3298,7 +3347,7 @@ Please login on the host and check output of the commands:&#13;
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>Discovery of file systems.</description>
           <item_prototypes>
             <item_prototype>
@@ -3308,7 +3357,7 @@ Please login on the host and check output of the commands:&#13;
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},pfree]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>1w</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>0</value_type>
@@ -3350,7 +3399,7 @@ Please login on the host and check output of the commands:&#13;
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},total]</key>
               <delay>1h</delay>
-              <history>2w</history>
+              <history>1w</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3392,7 +3441,7 @@ Please login on the host and check output of the commands:&#13;
               <snmp_oid/>
               <key>vfs.fs.size[{#FSNAME},used]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>1w</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>

--- a/OS Windows/OS Windows.xml
+++ b/OS Windows/OS Windows.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T03:53:55Z</date>
+  <date>2017-12-09T23:26:33Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -24,7 +24,7 @@ Notes:</description>
       </groups>
       <applications>
         <application>
-          <name>BITL</name>
+          <name>BLOC</name>
         </application>
         <application>
           <name>CPU</name>
@@ -43,6 +43,9 @@ Notes:</description>
         </application>
         <application>
           <name>HW::CPU</name>
+        </application>
+        <application>
+          <name>HW::NIC</name>
         </application>
         <application>
           <name>LOG</name>
@@ -91,6 +94,9 @@ Notes:</description>
         </application>
         <application>
           <name>SYS</name>
+        </application>
+        <application>
+          <name>SYS::SRV</name>
         </application>
         <application>
           <name>TSS</name>
@@ -212,6 +218,375 @@ Notes:</description>
           <applications>
             <application>
               <name>LOG</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Copy Read Hits</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Copy Read Hits %]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units>%</units>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for hit rates and miss rates. Any value over 80 percent indicates that the application uses the cache very efficiently. Compare this counter against Cache\Copy Reads/sec to see how many hits you are really getting. Even though the hit percentage is small, if the rate of operations is high, this might indicate better cache effectiveness than a high percentage with a low rate of operations.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Copy Reads</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Copy Reads/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter to see the rate at which the file system attempts to find application data in the cache without accessing the disk. This is a count of all copy read calls to the cache, including hits and misses. Copy reads are the usual method by which file data found in the cache is copied into an applications memory buffers.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Data Flushes</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Data Flushes/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which cache data is being written back to disk. This counter reports application requests to flush data from the cache and is an indirect indicator of the volume and frequency of application data changes.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Data Flush Pages</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Data Flush Pages/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which both applications change pages of cached data and the pages are written back to disk. This includes pages that have been written by the system process when many changed pages have accumulated, pages that have been flushed so that the cache can be trimmed, and disk writes that are caused by an application write-through request.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Data Maps</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Data Maps/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which file systems map pages of a file into the cache for reading. This counter reports read-only access to file system directories, the file allocation table (FAT) in the FAT file system, and the Master File Table in the NTFS file system. This counter does not reflect cache use by applications.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Fast Reads</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Fast Reads/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which applications bypass the file system and access data directly from the cache. A value over 50 percent indicates the application is behaving efficiently. Fast reads reduce processor overhead and are preferable to I/O requests.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Lazy Write Flushes</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Lazy Write Flushes/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which an application changes data, causing the cache to write to the disk and flush the data. If this value reflects an upward trend, memory might be becoming low. Lazy write flushes are a subset of data flushes. The lazy writer thread in the system process periodically writes changed pages from the modified page list back to disk and flushes them from the cache. This thread is activated more often when memory needs to be released for other uses. This counter counts the number of write and flush operations, regardless of the amount of data written.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Lazy Write Pages</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Lazy Write Pages/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which pages are changed by an application and written to the disk. If the counter value is increasing, this can indicate that memory is becoming low. Cache\Lazy Write Pages are a subset of Data Flush Pages.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::CAC::Read Aheads</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Cache\Read Aheads/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter to monitor the rate at which the Cache Manager detects that the file is being accessed sequentially. Sequential file access is a very efficient strategy in most cases. During sequential file access, the Cache Manager can read larger blocks of data into the cache on each I/O, thereby reducing the overhead per access.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
             </application>
           </applications>
           <valuemap/>
@@ -390,7 +765,7 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::available</name>
+          <name>MEM::Available</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
@@ -417,7 +792,7 @@ TypePerf.exe -qx on cmd prompt&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>Amount of physical memory immediately available for allocation to a process or for system use. It is equal to the sum of memory assigned to the standby (cached), free and zero page lists. Can also be indication of how much physical memory is remaining after the working sets of running processes and the cache have been served.</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -431,7 +806,48 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::commit::limit</name>
+          <name>MEM::CAC::Faults</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Memory\Cache Faults/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Counter for the rate at which pages sought in the cache were not found there and had to be obtained elsewhere in memory or on the disk. Compare this counter against Memory\Page Faults/sec and Pages Input/sec to determine the number of hard page faults, if any.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::Commit Limit</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
@@ -458,7 +874,10 @@ TypePerf.exe -qx on cmd prompt&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>The system commit limit of Windows and Windows Server is the sum of physical memory and the size of all of the page files combined on the system. It is the maximum amount of physical resources that the system can use to back committed memory. It is a factitious resource that prevents the system from over committing or over "promising" too much physical resources. With that said, when the system is unable to commit anymore memory, then applications may fail to function and the system may hang indefinitely.&#13;
+&#13;
+&#13;
+https://social.technet.microsoft.com/wiki/contents/articles/2248.perfguide-out-of-system-committed-memory.aspx</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -472,7 +891,7 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::committed</name>
+          <name>MEM::Committed</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
@@ -499,7 +918,9 @@ TypePerf.exe -qx on cmd prompt&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>Committed memory is the physical memory which has space reserved on the disk paging file(s). There can be one or more paging files on each physical drive. &#13;
+&#13;
+https://blogs.technet.microsoft.com/askperf/2008/01/25/an-overview-of-troubleshooting-memory-issues/</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -513,12 +934,12 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::free::FSPTE</name>
+          <name>MEM::PTE::Free entries</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
           <key>perf_counter[\Memory\Free System Page Table Entries]</key>
-          <delay>1m</delay>
+          <delay>10m</delay>
           <history>2w</history>
           <trends>365d</trends>
           <status>0</status>
@@ -540,7 +961,9 @@ TypePerf.exe -qx on cmd prompt&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>A page table is the data structure used by the Windows Virtual Memory Manager (VMM) to store the mapping between virtual addresses and physical addresses in memory. The performance counter Free System Page Table Entries is the number of page table entries not currently used by the system. More important to observe with 32-bit Windows OS.&#13;
+&#13;
+https://blogs.technet.microsoft.com/clint_huffman/2008/04/07/free-system-page-table-entries-ptes/</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -554,11 +977,11 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::pages</name>
+          <name>MEM::Page Faults</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
-          <key>perf_counter[\Memory\Pages/sec]</key>
+          <key>perf_counter[\Memory\Page Faults/sec]</key>
           <delay>1m</delay>
           <history>2w</history>
           <trends>365d</trends>
@@ -595,11 +1018,134 @@ TypePerf.exe -qx on cmd prompt&#13;
           <master_item/>
         </item>
         <item>
-          <name>MEM::pages::input</name>
+          <name>MEM::Page Reads</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Memory\Page Reads/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units>pages/s</units>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description/>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::Pages</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Memory\Pages/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Indicates the number of requested pages that were not immediately available in RAM and had to be read from the disk or had to be written to the disk to make room in RAM for other pages. If your system experiences a high rate of hard page faults, the value for Memory\Pages/sec can be high.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::Pages Input</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
           <key>perf_counter[\Memory\Pages Input/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description/>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>MEM</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>MEM::Pages Output</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Memory\Pages Output/sec]</key>
           <delay>1m</delay>
           <history>2w</history>
           <trends>365d</trends>
@@ -2124,6 +2670,47 @@ http://www.osronline.com/article.cfm?article=529</description>
           <master_item/>
         </item>
         <item>
+          <name>CPU::Processor::Frequency</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Processor Information(_Total)\Processor Frequency]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>0</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description/>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>HW::CPU</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
           <name>CPU::Processor::State Flags</name>
           <type>7</type>
           <snmp_community/>
@@ -2411,7 +2998,89 @@ http://www.osronline.com/article.cfm?article=529</description>
           <master_item/>
         </item>
         <item>
-          <name>SYS::Server Bytes Total</name>
+          <name>SYS::SRV::SMB::Blocking Requests Rejected</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Blocking Requests Rejected]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of times that the server has rejected blocking server message block requests (SMBs) due to insufficient count of free work items. This counter indicates whether the MaxWorkItem or MinFreeWorkItems server registry parameters might need tuning.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Server Bytes Received</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Bytes Received/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units>Bps</units>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the rate at which the server is receiving bytes from the network.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Server Bytes Total</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
@@ -2438,11 +3107,381 @@ http://www.osronline.com/article.cfm?article=529</description>
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>Shows the rate at which the server is transmitting bytes through the network.</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SYS</name>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Server Bytes Transmitted</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Bytes Transmitted/sec]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units>Bps</units>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the rate at which the server is sending bytes on the network.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Errors Access Permissions</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Errors Access Permissions]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of times attempts to open files on behalf of clients have failed with the message STATUS_ACCESS_DENIED. This counter can indicate if someone is attempting to access random files to improperly access a file that was not properly protected.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Errors Granted Access</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Errors Granted Access]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of times that attempts to access files successfully opened were denied. This counter can indicate attempts to access files without proper access authorization.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Errors Logon</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Errors Logon]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of failed logon attempts to the server. This counter can indicate whether password guessing programs are being used to crack the security on the server.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Errors System</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Errors System]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of times that an internal server error was detected. Errors can reflect problems with logon, security, memory allocation, disk operations, transport driver interface operations, communication (such as receipt of unimplemented or unrecognized SMBs), or I/O Request Packet stack size for the server.&#13;
+Many of these errors are also written to the System log and Security log in Event Viewer. The server can recover from most the errors displayed by this counter, but they are unexpected and should be reported to Microsoft Product Support Services.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Sessions Errored Out</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Sessions Errored Out]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of sessions that have been closed due to unexpected error conditions. This counter indicates how frequently network problems are causing dropped sessions on the server. The Sessions Errored Out counter reports auto-disconnects along with errored-out sessions. For a more accurate value for errored-out sessions, obtain the value for Sessions Timed Out and reduce the Sessions Errored Out value by that amount.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Sessions Forced Off</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Sessions Forced Off]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of sessions that have been forced to log off. This counter can indicate how many sessions were forced to log off due to logon time constraints.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Sessions Logged Off</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Sessions Logged Off]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of sessions that have been forced to log off. This counter can indicate how many sessions were forced to log off due to logon time constraints.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
+            </application>
+          </applications>
+          <valuemap/>
+          <logtimefmt/>
+          <preprocessing/>
+          <jmx_endpoint/>
+          <master_item/>
+        </item>
+        <item>
+          <name>SYS::SRV::Sessions Timed Out</name>
+          <type>7</type>
+          <snmp_community/>
+          <snmp_oid/>
+          <key>perf_counter[\Server\Sessions Timed Out]</key>
+          <delay>1m</delay>
+          <history>2w</history>
+          <trends>365d</trends>
+          <status>0</status>
+          <value_type>3</value_type>
+          <allowed_hosts/>
+          <units/>
+          <snmpv3_contextname/>
+          <snmpv3_securityname/>
+          <snmpv3_securitylevel>0</snmpv3_securitylevel>
+          <snmpv3_authprotocol>0</snmpv3_authprotocol>
+          <snmpv3_authpassphrase/>
+          <snmpv3_privprotocol>0</snmpv3_privprotocol>
+          <snmpv3_privpassphrase/>
+          <params/>
+          <ipmi_sensor/>
+          <authtype>0</authtype>
+          <username/>
+          <password/>
+          <publickey/>
+          <privatekey/>
+          <port/>
+          <description>Shows the number of sessions that have been closed because idle time exceeded the AutoDisconnect parameter for the server. This counter shows whether the AutoDisconnect setting is helping to conserve resources.</description>
+          <inventory_link>0</inventory_link>
+          <applications>
+            <application>
+              <name>SYS::SRV</name>
             </application>
           </applications>
           <valuemap/>
@@ -3158,7 +4197,7 @@ lowered from 10 -&gt; 5 second updates as characteristics observed are very diff
           <master_item/>
         </item>
         <item>
-          <name>SYS::Uptime</name>
+          <name>SYS::uptime</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>

--- a/OS Windows/README.md
+++ b/OS Windows/README.md
@@ -1,6 +1,13 @@
 Base OS Windows template.
 
-Version: 1.0.1 (2017-11-30)
+Version: 1.0.2 (2017-12-10)
+
+Changelog:
+- 1.0.2 
+  - Added more items from typeperf counters. (ss)
+  - Added more item descriptions (ss)
+  - Changed Bitlocker from BITL to BLOC as application name. (ss)
+  - Added additional application MEM::CAC, for items specifically related to cached memory (ss) 
 
 Changelog:
 - 1.0.1 (2017-11-30):

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Notes:
 * Each template in the description field has the last modification date and internal version
 
 Templated items, applications and triggers must adhere to this naming convention using 3-4 letter abbreviations:
-CLASS::Name
-CLASS::SUBCLASS::Name
+<<CLASS::Name>>
+<<CLASS::SUBCLASS::Name>>
 
 Examples:
-MEM::Total memory
+MEM::Total Memory
 NET::ICMP::Loss
 NTP::WTS::Clock Frequency Adjustment
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,21 @@ Notes:
 * If it is something which needs to be done to use those templates it is described in each template within description notes
 * Each template in the description field has the last modification date and internal version
 
-Templated items, applications and triggers adhere to this naming convention:
+Templated items, applications and triggers must adhere to this naming convention using 3-4 letter abbreviations:
+CLASS::Name
 CLASS::SUBCLASS::Name
+
+Examples:
+MEM::Total memory
+NET::ICMP::Loss
+NTP::WTS::Clock Frequency Adjustment
 
 This is to provide a parseable name, allowing us to distinguish between and categorise those objects.
 Such convention is quite easy to handle as pattern in alarming layer allowing for example send all tigger with SYS:: in the beginning name of the template to exact team.
 Such pattern is possible to use part of the general interface on communication with external services.
 
-* Do not use {HOSTNAME} macros in triggers as web frontend in trigger list in other column is name of the host on which trigger is active (it is waste of space on web page)
- 
+* Do not use {HOSTNAME} macros in triggers, as web frontend from Monitoring -> Triggers has a list with "host" column name on the host where the trigger is active (it is waste of space on web page)
+
 ## Copyright (C) 2017 Tomasz Kłoczko <kloczek@fedoraproject.org>
 
 ## This program is free software, distributed under the terms of the GNU General Public License Version 2.

--- a/Service Apache/Service Apache.xml
+++ b/Service Apache/Service Apache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T03:44:05Z</date>
+  <date>2017-12-09T23:26:31Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -12,13 +12,17 @@
       <template>Service Apache</template>
       <name>Service Apache</name>
       <description>Apache service monitoring template using zabbix active agent items.&#13;
+This template uses apache mod_status metrics.&#13;
+To use this template in apache configuration needs to be added:&#13;
 &#13;
-Version : 1.0.1 (2017-12-01)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/Service%20Apache&#13;
+Current version : 1.0&#13;
+Date:                   2017-09-09&#13;
+Changelog:&#13;
+1.0:&#13;
+- initial version.&#13;
 &#13;
 Notes:&#13;
-- This template uses apache mod_status metrics.&#13;
-- To use this template in apache configuration needs to be added:&#13;
+* To allow use this template in apache configuration must be present:&#13;
 &#13;
 ExtendedStatus On&#13;
 &lt;Location /server-status&gt;&#13;

--- a/Service MySQL/Service MySQL.xml
+++ b/Service MySQL/Service MySQL.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-07T09:32:05Z</date>
+  <date>2017-12-09T23:26:32Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -13,8 +13,19 @@
       <name>Service MySQL</name>
       <description>Active agent monitoring of the MySQL engine.&#13;
 &#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/Service%20MySQL&#13;
-Version: 1.0.3 (2017-11-30)&#13;
+Current version : 1.0.2&#13;
+Date:                   2017-10-23&#13;
+Changelog:&#13;
+1.0.2&#13;
+- replace use @MySQL::DB global regexp in MySQL::DB LLD by in place regexp (remove global regexp dependency)&#13;
+- change LLDs update interval from 1 to 30min&#13;
+&#13;
+1.0.1:&#13;
+- added missing entries in SVC::MySQL::Queries screen&#13;
+&#13;
+1.0:&#13;
+- initial version.&#13;
+&#13;
 Notes:&#13;
 * Tested on MySQL 5.7 and it not uses MySQL 5.6 backward compatibility so it can be used to monitor MySQL engine which in my.cnf has:&#13;
 &#13;
@@ -51,16 +62,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <name>SVC::MySQL::cfg</name>
         </application>
         <application>
-          <name>SVC::MySQL::Com</name>
-        </application>
-        <application>
-          <name>SVC::MySQL::innodb</name>
-        </application>
-        <application>
           <name>SVC::MySQL::QChache</name>
-        </application>
-        <application>
-          <name>SVC::MySQL::threads</name>
         </application>
       </applications>
       <items>
@@ -71,7 +73,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>proc.num[mysqld]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -114,7 +116,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/begin'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -139,7 +141,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -160,7 +162,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/commit'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -185,7 +187,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -206,7 +208,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/delete'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -231,7 +233,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -252,7 +254,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/insert'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -277,7 +279,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -298,7 +300,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/rollback'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -323,7 +325,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -344,7 +346,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/select'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -369,7 +371,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -390,7 +392,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT count_star FROM performance_schema.events_statements_summary_global_by_event_name WHERE event_name='statement/sql/update'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -415,7 +417,7 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::Com</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -430,138 +432,13 @@ http://dev.mysql.com/doc/refman/5.7/en/innodb-information-schema.html</descripti
           <master_item/>
         </item>
         <item>
-          <name>show_compatibility_56</name>
-          <type>7</type>
-          <snmp_community/>
-          <snmp_oid/>
-          <key>system.run[{$MYSQL_CMD} "SELECT variable_name= FROM performance_schema.global_status WHERE variable_name='show_compatibility_56'",]</key>
-          <delay>1h</delay>
-          <history>2w</history>
-          <trends>0</trends>
-          <status>0</status>
-          <value_type>1</value_type>
-          <allowed_hosts/>
-          <units/>
-          <snmpv3_contextname/>
-          <snmpv3_securityname/>
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase/>
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase/>
-          <params/>
-          <ipmi_sensor/>
-          <authtype>0</authtype>
-          <username/>
-          <password/>
-          <publickey/>
-          <privatekey/>
-          <port/>
-          <description>When show_compatibility_56 is OFF, compatibility with MySQL 5.6 is disabled and several changes result.</description>
-          <inventory_link>0</inventory_link>
-          <applications>
-            <application>
-              <name>SVC::MySQL::cfg</name>
-            </application>
-          </applications>
-          <valuemap/>
-          <logtimefmt/>
-          <preprocessing/>
-          <jmx_endpoint/>
-          <master_item/>
-        </item>
-        <item>
-          <name>Threads_cached</name>
-          <type>7</type>
-          <snmp_community/>
-          <snmp_oid/>
-          <key>system.run[{$MYSQL_CMD} "SELECT variable_name FROM performance_schema.global_status where variable_name='Threads_cached';",]</key>
-          <delay>20s</delay>
-          <history>2w</history>
-          <trends>365d</trends>
-          <status>0</status>
-          <value_type>3</value_type>
-          <allowed_hosts/>
-          <units>threads</units>
-          <snmpv3_contextname/>
-          <snmpv3_securityname/>
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase/>
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase/>
-          <params/>
-          <ipmi_sensor/>
-          <authtype>0</authtype>
-          <username/>
-          <password/>
-          <publickey/>
-          <privatekey/>
-          <port/>
-          <description>The number of threads in the thread cache.&#13;
-&#13;
-This variable is not meaningful in the embedded server (libmysqld) and as of MySQL 5.7.2 is no longer visible within the embedded server.</description>
-          <inventory_link>0</inventory_link>
-          <applications>
-            <application>
-              <name>SVC::MySQL::threads</name>
-            </application>
-          </applications>
-          <valuemap/>
-          <logtimefmt/>
-          <preprocessing/>
-          <jmx_endpoint/>
-          <master_item/>
-        </item>
-        <item>
-          <name>Threads_running</name>
-          <type>7</type>
-          <snmp_community/>
-          <snmp_oid/>
-          <key>system.run[{$MYSQL_CMD} "SELECT variable_name FROM performance_schema.global_status WHERE variable_name='Threads_running';",]</key>
-          <delay>20s</delay>
-          <history>2w</history>
-          <trends>365d</trends>
-          <status>0</status>
-          <value_type>3</value_type>
-          <allowed_hosts/>
-          <units>threads</units>
-          <snmpv3_contextname/>
-          <snmpv3_securityname/>
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase/>
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase/>
-          <params/>
-          <ipmi_sensor/>
-          <authtype>0</authtype>
-          <username/>
-          <password/>
-          <publickey/>
-          <privatekey/>
-          <port/>
-          <description>The number of threads that are not sleeping.</description>
-          <inventory_link>0</inventory_link>
-          <applications>
-            <application>
-              <name>SVC::MySQL::threads</name>
-            </application>
-          </applications>
-          <valuemap/>
-          <logtimefmt/>
-          <preprocessing/>
-          <jmx_endpoint/>
-          <master_item/>
-        </item>
-        <item>
           <name>binlog_format</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT variable_value FROM performance_schema.global_status WHERE variable_name='binlog_format'",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -608,7 +485,7 @@ This variable sets the binary logging format, and can be any one of STATEMENT, R
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT variable_value FROM performance_schema.global_status WHERE variable_name='Bytes_received'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -654,7 +531,7 @@ This variable sets the binary logging format, and can be any one of STATEMENT, R
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "SELECT variable_value FROM performance_schema.global_status WHERE variable_name='Bytes_sent'",]</key>
           <delay>10s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -700,7 +577,7 @@ This variable sets the binary logging format, and can be any one of STATEMENT, R
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Connections';",]</key>
           <delay>20s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -746,7 +623,7 @@ This variable sets the binary logging format, and can be any one of STATEMENT, R
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Created_tmp_disk_tables';",]</key>
           <delay>20s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -796,7 +673,7 @@ You can compare the number of internal on-disk temporary tables created to the t
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Created_tmp_files';",]</key>
           <delay>20s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -842,7 +719,7 @@ You can compare the number of internal on-disk temporary tables created to the t
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Created_tmp_tables';",]</key>
           <delay>20s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -892,7 +769,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_bytes_data';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -917,7 +794,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -933,7 +810,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_bytes_dirty';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -958,7 +835,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -974,7 +851,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_data';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -999,7 +876,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1015,7 +892,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1040,7 +917,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1056,7 +933,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_flushed';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1081,7 +958,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1102,7 +979,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_free';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1127,7 +1004,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1143,7 +1020,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_misc';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1168,7 +1045,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1184,7 +1061,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_pages_total';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1209,7 +1086,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1225,7 +1102,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_reads';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1250,7 +1127,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1271,7 +1148,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_read_requests';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1296,7 +1173,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1317,7 +1194,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_buffer_pool_write_requests';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1342,7 +1219,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1363,7 +1240,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_fsyncs';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1388,7 +1265,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1409,7 +1286,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_pending_fsyncs';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1434,7 +1311,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1450,7 +1327,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_pending_reads';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1475,7 +1352,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1491,7 +1368,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_pending_writes';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1516,7 +1393,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1532,7 +1409,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_read';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1557,7 +1434,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1578,7 +1455,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_data_writes';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1603,7 +1480,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1619,7 +1496,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_log_waits';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1644,7 +1521,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1665,7 +1542,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_log_write_requests';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -1690,7 +1567,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1711,7 +1588,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_os_log_written';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1736,7 +1613,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1757,7 +1634,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_rows_inserted';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1782,7 +1659,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1803,7 +1680,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_rows_read';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1828,7 +1705,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1849,7 +1726,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_rows_updated';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1874,7 +1751,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1895,7 +1772,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_row_lock_time_avg';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1920,7 +1797,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1941,7 +1818,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Innodb_row_lock_waits';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -1966,7 +1843,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::innodb</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -1987,7 +1864,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_free_blocks'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2028,7 +1905,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_free_memory'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2069,7 +1946,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_hits'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2115,7 +1992,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_inserts'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2161,7 +2038,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_lowmem_prunes'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2207,7 +2084,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_not_cached'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2253,7 +2130,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_queries_in_cache'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2294,7 +2171,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Qcache_total_blocks'",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2335,7 +2212,7 @@ Each invocation of the SHOW STATUS statement uses an internal temporary table an
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Queries';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2383,7 +2260,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Select_scan';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2429,7 +2306,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Slow_queries';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>0</value_type>
@@ -2475,7 +2352,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Threads_connected';",]</key>
           <delay>20s</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2500,7 +2377,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::threads</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -2516,7 +2393,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Threads_created';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2541,7 +2418,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
-              <name>SVC::MySQL::threads</name>
+              <name>SVC::MySQL</name>
             </application>
           </applications>
           <valuemap/>
@@ -2557,7 +2434,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Uptime';",]</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2598,7 +2475,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='event_scheduler';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -2645,7 +2522,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='innodb_max_dirty_pages_pct';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2686,7 +2563,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='innodb_open_files';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2727,7 +2604,7 @@ It does not count COM_PING or COM_STATISTICS commands.</description>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='innodb_page_size';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2770,7 +2647,7 @@ The default, with the largest page size, is appropriate for a wide range of work
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='innodb_support_xa';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -2815,7 +2692,7 @@ You can also turn off this option if you do not need it for safe binary logging 
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='long_query_time';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2850,60 +2727,13 @@ You can also turn off this option if you do not need it for safe binary logging 
           <master_item/>
         </item>
         <item>
-          <name>max_allowed_packet</name>
-          <type>7</type>
-          <snmp_community/>
-          <snmp_oid/>
-          <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='max_allowed_packet';",]</key>
-          <delay>1h</delay>
-          <history>2w</history>
-          <trends>365d</trends>
-          <status>0</status>
-          <value_type>3</value_type>
-          <allowed_hosts/>
-          <units>B</units>
-          <snmpv3_contextname/>
-          <snmpv3_securityname/>
-          <snmpv3_securitylevel>0</snmpv3_securitylevel>
-          <snmpv3_authprotocol>0</snmpv3_authprotocol>
-          <snmpv3_authpassphrase/>
-          <snmpv3_privprotocol>0</snmpv3_privprotocol>
-          <snmpv3_privpassphrase/>
-          <params/>
-          <ipmi_sensor/>
-          <authtype>0</authtype>
-          <username/>
-          <password/>
-          <publickey/>
-          <privatekey/>
-          <port/>
-          <description>The maximum size of one packet or any generated/intermediate string, or any parameter sent by the mysql_stmt_send_long_data() C API function. The default is 4MB (4194304 bytes).&#13;
-&#13;
-The packet message buffer is initialized to net_buffer_length bytes, but can grow up to max_allowed_packet bytes when needed. This value by default is small, to catch large (possibly incorrect) packets.&#13;
-&#13;
-You must increase this value if you are using large BLOB columns or long strings. It should be as big as the largest BLOB you want to use. The protocol limit for max_allowed_packet is 1GB. The value should be a multiple of 1024; nonmultiples are rounded down to the nearest multiple.&#13;
-&#13;
-When you change the message buffer size by changing the value of the max_allowed_packet variable, you should also change the buffer size on the client side if your client program permits it. The default max_allowed_packet value built in to the client library is 1GB, but individual client programs might override this. For example, mysql and mysqldump have defaults of 16MB and 24MB, respectively. They also enable you to change the client-side value by setting max_allowed_packet on the command line or in an option file.</description>
-          <inventory_link>0</inventory_link>
-          <applications>
-            <application>
-              <name>SVC::MySQL::cfg</name>
-            </application>
-          </applications>
-          <valuemap/>
-          <logtimefmt/>
-          <preprocessing/>
-          <jmx_endpoint/>
-          <master_item/>
-        </item>
-        <item>
           <name>max_connections</name>
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='max_connections';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2944,7 +2774,7 @@ When you change the message buffer size by changing the value of the max_allowed
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='max_heap_table_size';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -2987,7 +2817,7 @@ This variable is also used in conjunction with tmp_table_size to limit the size 
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='open_files_limit';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -3028,7 +2858,7 @@ This variable is also used in conjunction with tmp_table_size to limit the size 
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='query_cache_size';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -3073,7 +2903,7 @@ The query cache needs a minimum size of about 40KB to allocate its structures. (
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='query_cache_type';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -3119,7 +2949,7 @@ Possible values:&#13;
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='tmp_table_size';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -3162,7 +2992,7 @@ You can compare the number of internal on-disk temporary tables created to the t
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='tx_isolation';",]</key>
           <delay>1h</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -3227,7 +3057,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
           <snmp_oid/>
           <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='version';",]</key>
           <delay>1d</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -3269,7 +3099,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
           <snmp_community/>
           <snmp_oid/>
           <key>system.run["{$MYSQL_CMD} 'show databases'|awk 'BEGIN {print \"{\\"data\\":[\"; ORS=\"\"} {if (NR&gt;1) {print \",\n\"}; print \"{\\"{#DB}\\":\\"\" $1 \"\\"}\"} END {print \"]}\"}'"]</key>
-          <delay>10m</delay>
+          <delay>30m</delay>
           <status>0</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -3293,13 +3123,13 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
             <conditions>
               <condition>
                 <macro>{#DB}</macro>
-                <value>^(?!(information_schema|mysql|performance_schema|sys))</value>
+                <value>(?!(information_schema|mysqlperformance_schema|sys))</value>
                 <operator>8</operator>
                 <formulaid>A</formulaid>
               </condition>
             </conditions>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>0d</lifetime>
           <description>Discover list of available databases.</description>
           <item_prototypes>
             <item_prototype>
@@ -3309,7 +3139,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
               <snmp_oid/>
               <key>system.run[{$MYSQL_CMD} "select SUM(DATA_LENGTH) from information_schema.TABLES where TABLE_SCHEMA='{#DB}';",]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3332,16 +3162,16 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
               <port/>
               <description>Database {#DB} sun of all tables data size.</description>
               <inventory_link>0</inventory_link>
-              <applications/>
+              <applications>
+                <application>
+                  <name>SVC::MySQL</name>
+                </application>
+              </applications>
               <valuemap/>
               <logtimefmt/>
               <preprocessing/>
               <jmx_endpoint/>
-              <application_prototypes>
-                <application_prototype>
-                  <name>SVC::MySQL::DB::{#DB}</name>
-                </application_prototype>
-              </application_prototypes>
+              <application_prototypes/>
               <master_item_prototype/>
             </item_prototype>
             <item_prototype>
@@ -3351,7 +3181,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
               <snmp_oid/>
               <key>system.run[{$MYSQL_CMD} "select SUM(INDEX_LENGTH) from information_schema.TABLES where TABLE_SCHEMA='{#DB}';",]</key>
               <delay>1m</delay>
-              <history>2w</history>
+              <history>15d</history>
               <trends>365d</trends>
               <status>0</status>
               <value_type>3</value_type>
@@ -3374,16 +3204,16 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
               <port/>
               <description>Database {#DB} sun of all indexes size.</description>
               <inventory_link>0</inventory_link>
-              <applications/>
+              <applications>
+                <application>
+                  <name>SVC::MySQL</name>
+                </application>
+              </applications>
               <valuemap/>
               <logtimefmt/>
               <preprocessing/>
               <jmx_endpoint/>
-              <application_prototypes>
-                <application_prototype>
-                  <name>SVC::MySQL::DB::{#DB}</name>
-                </application_prototype>
-              </application_prototypes>
+              <application_prototypes/>
               <master_item_prototype/>
             </item_prototype>
           </item_prototypes>
@@ -3443,7 +3273,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
           <snmp_community/>
           <snmp_oid/>
           <key>system.run[mysql -sNe  "",]</key>
-          <delay>10m</delay>
+          <delay>30m</delay>
           <status>1</status>
           <allowed_hosts/>
           <snmpv3_contextname/>
@@ -3466,7 +3296,7 @@ This level is like REPEATABLE READ, but InnoDB implicitly converts all plain SEL
             <formula/>
             <conditions/>
           </filter>
-          <lifetime>1d</lifetime>
+          <lifetime>31d</lifetime>
           <description>Slave process monitoring.&#13;
 &#13;
 Detection is slave running bases on query:&#13;
@@ -3632,11 +3462,11 @@ SELECT variable_value FROM information_schema.global_status WHERE variable_name 
         <screen>
           <name>SVC::MySQL::DBs</name>
           <hsize>2</hsize>
-          <vsize>1</vsize>
+          <vsize>5</vsize>
           <screen_items>
             <screen_item>
               <resourcetype>20</resourcetype>
-              <width>900</width>
+              <width>500</width>
               <height>100</height>
               <x>0</x>
               <y>0</y>
@@ -3753,106 +3583,15 @@ SELECT variable_value FROM information_schema.global_status WHERE variable_name 
             </screen_item>
           </screen_items>
         </screen>
-        <screen>
-          <name>SVC::MySQL::threads</name>
-          <hsize>1</hsize>
-          <vsize>3</vsize>
-          <screen_items>
-            <screen_item>
-              <resourcetype>0</resourcetype>
-              <width>900</width>
-              <height>200</height>
-              <x>0</x>
-              <y>0</y>
-              <colspan>1</colspan>
-              <rowspan>1</rowspan>
-              <elements>0</elements>
-              <valign>1</valign>
-              <halign>1</halign>
-              <style>0</style>
-              <url/>
-              <dynamic>0</dynamic>
-              <sort_triggers>0</sort_triggers>
-              <resource>
-                <name>SVC::MySQL::threads</name>
-                <host>Service MySQL</host>
-              </resource>
-              <max_columns>3</max_columns>
-              <application/>
-            </screen_item>
-            <screen_item>
-              <resourcetype>1</resourcetype>
-              <width>900</width>
-              <height>100</height>
-              <x>0</x>
-              <y>1</y>
-              <colspan>1</colspan>
-              <rowspan>1</rowspan>
-              <elements>0</elements>
-              <valign>0</valign>
-              <halign>1</halign>
-              <style>0</style>
-              <url/>
-              <dynamic>0</dynamic>
-              <sort_triggers>0</sort_triggers>
-              <resource>
-                <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Threads_created';",]</key>
-                <host>Service MySQL</host>
-              </resource>
-              <max_columns>3</max_columns>
-              <application/>
-            </screen_item>
-            <screen_item>
-              <resourcetype>1</resourcetype>
-              <width>900</width>
-              <height>100</height>
-              <x>0</x>
-              <y>2</y>
-              <colspan>1</colspan>
-              <rowspan>1</rowspan>
-              <elements>0</elements>
-              <valign>1</valign>
-              <halign>1</halign>
-              <style>0</style>
-              <url/>
-              <dynamic>0</dynamic>
-              <sort_triggers>0</sort_triggers>
-              <resource>
-                <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Connections';",]</key>
-                <host>Service MySQL</host>
-              </resource>
-              <max_columns>3</max_columns>
-              <application/>
-            </screen_item>
-          </screen_items>
-        </screen>
       </screens>
     </template>
   </templates>
   <triggers>
     <trigger>
-      <expression>{Service MySQL:system.run[{$MYSQL_CMD} "SELECT variable_name= FROM performance_schema.global_status WHERE variable_name='show_compatibility_56'",].str(OFF)}=1</expression>
-      <recovery_mode>0</recovery_mode>
-      <recovery_expression/>
-      <name>SVC::MySQL::cfg::show_compatibility_56=OFF</name>
-      <correlation_mode>0</correlation_mode>
-      <correlation_tag/>
-      <url>https://dev.mysql.com/doc/refman/5.7/en/performance-schema-variable-table-migration.html</url>
-      <status>0</status>
-      <priority>4</priority>
-      <description>When show_compatibility_56 is OFF, compatibility with MySQL 5.6 is disabled and several changes result. &#13;
-&#13;
-This template requires show_compatibility_56=OFF</description>
-      <type>0</type>
-      <manual_close>0</manual_close>
-      <dependencies/>
-      <tags/>
-    </trigger>
-    <trigger>
       <expression>{Service MySQL:system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='event_scheduler';",].str(OFF)}=1</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
-      <name>SVC::MySQL::event_scheduler=OFF</name>
+      <name>SVC::MySQL::event_scheduler is OFF</name>
       <correlation_mode>0</correlation_mode>
       <correlation_tag/>
       <url/>
@@ -3877,10 +3616,10 @@ SET GLOBAL event_scheduler = ON;</description>
 {Service MySQL:system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='max_connections';",].last()}*0.9</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
-      <name>SVC::MySQL::Threads_connected &gt;= 90% max_connection</name>
+      <name>SVC::MySQL:Threads_connected &gt;= 90% max_connections</name>
       <correlation_mode>0</correlation_mode>
       <correlation_tag/>
-      <url>https://dev.mysql.com/doc/refman/5.7/en/server-status-variables.html#statvar_Threads_connected</url>
+      <url/>
       <status>0</status>
       <priority>2</priority>
       <description>Number threads with actoive connections is greater than 90% of maximum connections which MySQL engine can establish to the clients.&#13;
@@ -3891,22 +3630,6 @@ SET GLOBAL max_connections  = &lt;new_limit&gt;;&#13;
 To preserve this setting between restarts you need to add to my.cnf:&#13;
 &#13;
 max_connections = &lt;new_limit&gt;</description>
-      <type>0</type>
-      <manual_close>0</manual_close>
-      <dependencies/>
-      <tags/>
-    </trigger>
-    <trigger>
-      <expression>{Service MySQL:system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_variables where VARIABLE_NAME='version';",].diff()}&gt;0</expression>
-      <recovery_mode>0</recovery_mode>
-      <recovery_expression/>
-      <name>SVC::MySQL::version has changed to {ITEM.LASTVALUE}</name>
-      <correlation_mode>0</correlation_mode>
-      <correlation_tag/>
-      <url/>
-      <status>0</status>
-      <priority>0</priority>
-      <description>The MySQL engine version has been changed.</description>
       <type>0</type>
       <manual_close>0</manual_close>
       <dependencies/>
@@ -4267,62 +3990,6 @@ Possible restart has been done.</description>
           <item>
             <host>Service MySQL</host>
             <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Slow_queries';",]</key>
-          </item>
-        </graph_item>
-      </graph_items>
-    </graph>
-    <graph>
-      <name>SVC::MySQL::threads</name>
-      <width>900</width>
-      <height>400</height>
-      <yaxismin>0.0000</yaxismin>
-      <yaxismax>100.0000</yaxismax>
-      <show_work_period>1</show_work_period>
-      <show_triggers>1</show_triggers>
-      <type>0</type>
-      <show_legend>1</show_legend>
-      <show_3d>0</show_3d>
-      <percent_left>0.0000</percent_left>
-      <percent_right>0.0000</percent_right>
-      <ymin_type_1>0</ymin_type_1>
-      <ymax_type_1>0</ymax_type_1>
-      <ymin_item_1>0</ymin_item_1>
-      <ymax_item_1>0</ymax_item_1>
-      <graph_items>
-        <graph_item>
-          <sortorder>0</sortorder>
-          <drawtype>0</drawtype>
-          <color>1A7C11</color>
-          <yaxisside>0</yaxisside>
-          <calc_fnc>7</calc_fnc>
-          <type>0</type>
-          <item>
-            <host>Service MySQL</host>
-            <key>system.run[{$MYSQL_CMD} "select VARIABLE_VALUE from performance_schema.global_status where VARIABLE_NAME='Threads_connected';",]</key>
-          </item>
-        </graph_item>
-        <graph_item>
-          <sortorder>1</sortorder>
-          <drawtype>0</drawtype>
-          <color>F63100</color>
-          <yaxisside>0</yaxisside>
-          <calc_fnc>7</calc_fnc>
-          <type>0</type>
-          <item>
-            <host>Service MySQL</host>
-            <key>system.run[{$MYSQL_CMD} "SELECT variable_name FROM performance_schema.global_status WHERE variable_name='Threads_running';",]</key>
-          </item>
-        </graph_item>
-        <graph_item>
-          <sortorder>2</sortorder>
-          <drawtype>0</drawtype>
-          <color>2774A4</color>
-          <yaxisside>0</yaxisside>
-          <calc_fnc>7</calc_fnc>
-          <type>0</type>
-          <item>
-            <host>Service MySQL</host>
-            <key>system.run[{$MYSQL_CMD} "SELECT variable_name FROM performance_schema.global_status where variable_name='Threads_cached';",]</key>
           </item>
         </graph_item>
       </graph_items>

--- a/Service Zabbix Agent/Service Zabbix Agent.xml
+++ b/Service Zabbix Agent/Service Zabbix Agent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2017-12-01T14:49:55Z</date>
+  <date>2017-12-09T23:26:30Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -11,10 +11,13 @@
     <template>
       <template>Service Zabbix Agent</template>
       <name>Service Zabbix Agent</name>
-      <description>Base zabbix agent working in active mode monitoring.&#13;
+      <description>Base zabbix active agent monitoring.&#13;
 &#13;
-Version: 1.0.1 (2017-12-01)&#13;
-URL: https://github.com/kloczek/zabbix-templates/tree/master/Service%20Zabbix%20Agent&#13;
+Current version : 1.0&#13;
+Date:                   2017-09-09&#13;
+Changelog:&#13;
+1.0:&#13;
+- initial version.&#13;
 &#13;
 Notes:</description>
       <groups>
@@ -35,7 +38,7 @@ Notes:</description>
           <snmp_oid/>
           <key>agent.ping</key>
           <delay>1m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>
@@ -78,7 +81,7 @@ Notes:</description>
           <snmp_oid/>
           <key>agent.version</key>
           <delay>5m</delay>
-          <history>2w</history>
+          <history>15d</history>
           <trends>0</trends>
           <status>0</status>
           <value_type>1</value_type>
@@ -113,13 +116,13 @@ Notes:</description>
           <master_item/>
         </item>
         <item>
-          <name>items unsupported</name>
+          <name>items_unsupported]</name>
           <type>5</type>
           <snmp_community/>
           <snmp_oid/>
           <key>zabbix[host,,items_unsupported]</key>
           <delay>30s</delay>
-          <history>2w</history>
+          <history>90d</history>
           <trends>365d</trends>
           <status>0</status>
           <value_type>3</value_type>


### PR DESCRIPTION
Just double check what I've added, should have only been to windows template and readme only.
* Added more items from typeperf counters. 
* Added more item descriptions
* Changed Bitlocker from BITL to BLOC as application name.
* Added additional application MEM::CAC, for items specifically related to cached memory

I have not decided whether it is better to use application with SUBLASSES, for example HW and also HW::CPU or instead use SUBCLASSES in the item name instead, (as you will see all under MEM, some items are MEM:: others are MEM::CAC (maybe the 3-4 letter abbreviation should be something else for cache, but what?)
 