### PR TITLE
Adding a macro that is used to check whether SSH is running on a non-standard port

### DIFF
--- a/OS Linux/OS Linux.xml
+++ b/OS Linux/OS Linux.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
   <version>3.4</version>
-  <date>2018-06-11T11:38:28Z</date>
+  <date>2018-06-27T20:54:26Z</date>
   <groups>
     <group>
       <name>Templates</name>
@@ -153,7 +153,7 @@ Notes:&#13;
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
-          <key>net.tcp.port[,22]</key>
+          <key>net.tcp.port[,{$SVC_SSH_PORT}]</key>
           <delay>5m</delay>
           <history>2w</history>
           <trends>365d</trends>
@@ -176,7 +176,7 @@ Notes:&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>Check of possible create TCP connection to SSH port (configured macros).</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -196,7 +196,7 @@ Notes:&#13;
           <type>7</type>
           <snmp_community/>
           <snmp_oid/>
-          <key>net.tcp.service[ssh]</key>
+          <key>net.tcp.service[ssh,,{$SVC_SSH_PORT}]</key>
           <delay>5m</delay>
           <history>2w</history>
           <trends>365d</trends>
@@ -219,7 +219,7 @@ Notes:&#13;
           <publickey/>
           <privatekey/>
           <port/>
-          <description/>
+          <description>Check if SSH services is running and accepted connection.</description>
           <inventory_link>0</inventory_link>
           <applications>
             <application>
@@ -3561,6 +3561,10 @@ Value is calculated by read number of sectors multiplied by 512.</description>
           <macro>{$STEAL_WARN}</macro>
           <value>20</value>
         </macro>
+        <macro>
+          <macro>{$SVC_SSH_PORT}</macro>
+          <value>22</value>
+        </macro>
       </macros>
       <templates>
         <template>
@@ -4156,7 +4160,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
       <tags/>
     </trigger>
     <trigger>
-      <expression>{OS Linux:net.tcp.port[,22].count(#3,0)}=3</expression>
+      <expression>{OS Linux:net.tcp.port[,{$SVC_SSH_PORT}].count(#3,0)}=3</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
       <name>NET::port::ssh unreachable</name>
@@ -4178,7 +4182,7 @@ Value is calculated by read number of sectors multiplied by 512.</description>
       <tags/>
     </trigger>
     <trigger>
-      <expression>{OS Linux:net.tcp.service[ssh].count(#3,0)}=3</expression>
+      <expression>{OS Linux:net.tcp.service[ssh,,{$SVC_SSH_PORT}].count(#3,0)}=3</expression>
       <recovery_mode>0</recovery_mode>
       <recovery_expression/>
       <name>SVC::ssh is down</name>


### PR DESCRIPTION
Adding a macro that is used to check whether SSH is running on a non-standard port.
Macros: {$SVC_SSH_PORT}